### PR TITLE
Removed redundant dependencies on android support libraries. 

### DIFF
--- a/src/LaunchDarkly.XamarinSdk/LaunchDarkly.XamarinSdk.csproj
+++ b/src/LaunchDarkly.XamarinSdk/LaunchDarkly.XamarinSdk.csproj
@@ -56,24 +56,6 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
 
-  <!-- dependencies for Android 8.1 -->
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid81')) ">
-    <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="27.0.2.1" />
-    <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="27.0.2.1" />
-  </ItemGroup>
-
-  <!-- dependencies for Android 8.0 -->
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid80')) ">
-    <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="26.1.0.1" />
-    <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="26.1.0.1" />
-  </ItemGroup>
-
-  <!-- dependencies for Android 7.1 -->
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid71')) ">
-    <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="25.4.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="25.4.0.2" />
-  </ItemGroup>
-
   <!-- dependencies and source files for iOS (all versions) -->
   <ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.iOS')) ">
     <Compile Include="**\*.ios.cs" />

--- a/src/LaunchDarkly.XamarinSdk/PlatformSpecific/Permissions.android.cs
+++ b/src/LaunchDarkly.XamarinSdk/PlatformSpecific/Permissions.android.cs
@@ -27,8 +27,6 @@ using System.Threading.Tasks;
 using Android;
 using Android.Content.PM;
 using Android.OS;
-using Android.Support.V4.App;
-using Android.Support.V4.Content;
 
 namespace LaunchDarkly.Xamarin.PlatformSpecific
 {


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions
**Describe the solution you've provided**

Currently mono droid SDK has dependency on Android Support libraries but actually doesn't use them in code (I've checked only master branch). I'm suggesting to remove these redundant dependencies. This would allow to use your SDK package with mono droid 10 and Jetpack.

**Describe alternatives you've considered**

As alternative you could think about introducing dependencies on Jetpack instead of Support libs when platform is Mono Droid 10 (if you really need them somewhere).

**Additional context**

[Jetpack overview](https://developer.android.com/jetpack/getting-started)
Support libraries are no more maintained by Google and latest guides recommend to use Jetpack instead. These two sets of packages are not compatible with each other. On current project I can't use your SDK for mono droid 10 since I've integrated Jetpack there.

Thanks in advance.