### PR TITLE
Updates outdated Docs site URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to the LaunchDarkly Client-Side SDK for Xamarin
 
-LaunchDarkly has published an [SDK contributor's guide](https://docs.launchdarkly.com/docs/sdk-contributors-guide) that provides a detailed explanation of how our SDKs work. See below for additional information on how to contribute to this SDK.
+LaunchDarkly has published an [SDK contributor's guide](https://docs.launchdarkly.com/sdk/concepts/contributors-guide) that provides a detailed explanation of how our SDKs work. See below for additional information on how to contribute to this SDK.
 
 ## Submitting bug reports and feature requests
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ LaunchDarkly Client-Side SDK for Xamarin
 
 LaunchDarkly overview
 -------------------------
-[LaunchDarkly](https://www.launchdarkly.com) is a feature management platform that serves over 100 billion feature flags daily to help teams build better software, faster. [Get started](https://docs.launchdarkly.com/docs/getting-started) using LaunchDarkly today!
+[LaunchDarkly](https://www.launchdarkly.com) is a feature management platform that serves over 100 billion feature flags daily to help teams build better software, faster. [Get started](https://docs.launchdarkly.com/home/getting-started) using LaunchDarkly today!
 
 [![Twitter Follow](https://img.shields.io/twitter/follow/launchdarkly.svg?style=social&label=Follow&maxAge=2592000)](https://twitter.com/intent/follow?screen_name=launchdarkly)
 
@@ -19,7 +19,7 @@ Note that if you are targeting .NET Framework, there is a [known issue](https://
 Getting started
 -----------
 
-Refer to the [SDK documentation](https://docs.launchdarkly.com/docs/xamarin-sdk-reference#section-getting-started) for instructions on getting started with using the SDK.
+Refer to the [SDK documentation](https://docs.launchdarkly.com/sdk/client-side/xamarin#getting-started) for instructions on getting started with using the SDK.
 
 Learn more
 -----------
@@ -44,7 +44,7 @@ About LaunchDarkly
     * Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
     * Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
     * Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). Disable parts of your application to facilitate maintenance, without taking everything offline.
-* LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/docs) for a complete list.
+* LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
 * Explore LaunchDarkly
     * [launchdarkly.com](https://www.launchdarkly.com/ "LaunchDarkly Main Website") for more information
     * [docs.launchdarkly.com](https://docs.launchdarkly.com/  "LaunchDarkly Documentation") for our documentation and SDK reference guides

--- a/src/LaunchDarkly.XamarinSdk/ILdClient.cs
+++ b/src/LaunchDarkly.XamarinSdk/ILdClient.cs
@@ -240,7 +240,7 @@ namespace LaunchDarkly.Xamarin
         /// As of this version’s release date, the LaunchDarkly service does not support the <c>metricValue</c>
         /// parameter. As a result, calling this overload of <c>Track</c> will not yet produce any different
         /// behavior from calling <see cref="Track(String, LdValue)"/> without a <c>metricValue</c>.
-        /// Refer to the <a href="https://docs.launchdarkly.com/docs/xamarin-sdk-reference#section-track">SDK reference guide</a>
+        /// Refer to the <a href="https://docs.launchdarkly.com/sdk/features/events#xamarin">SDK reference guide</a>
         /// for the latest status.
         /// </remarks>
         /// <param name="eventName">the name of the event</param>

--- a/src/LaunchDarkly.XamarinSdk/ILdClient.cs
+++ b/src/LaunchDarkly.XamarinSdk/ILdClient.cs
@@ -237,8 +237,6 @@ namespace LaunchDarkly.Xamarin
         /// numeric metric value.
         /// </summary>
         /// <remarks>
-        /// Refer to the <a href="https://docs.launchdarkly.com/sdk/features/events#xamarin">SDK reference guide</a>
-        /// for the latest status.
         /// </remarks>
         /// <param name="eventName">the name of the event</param>
         /// <param name="data">a JSON value containing additional data associated with the event; pass

--- a/src/LaunchDarkly.XamarinSdk/ILdClient.cs
+++ b/src/LaunchDarkly.XamarinSdk/ILdClient.cs
@@ -237,9 +237,6 @@ namespace LaunchDarkly.Xamarin
         /// numeric metric value.
         /// </summary>
         /// <remarks>
-        /// As of this version’s release date, the LaunchDarkly service does not support the <c>metricValue</c>
-        /// parameter. As a result, calling this overload of <c>Track</c> will not yet produce any different
-        /// behavior from calling <see cref="Track(String, LdValue)"/> without a <c>metricValue</c>.
         /// Refer to the <a href="https://docs.launchdarkly.com/sdk/features/events#xamarin">SDK reference guide</a>
         /// for the latest status.
         /// </remarks>


### PR DESCRIPTION
**Requirements**

- [ n/a ] I have added test coverage for new or changed functionality
- [ X ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ n/a ] I have validated my changes against all supported platform versions

**Related issues**

N/A

**Describe the solution you've provided**

Updated old URLs linking to the old docs site to current URLs for the current docs site.

**Describe alternatives you've considered**

N/A

**Additional context**

Some docs site URLs changed in 2020 when we changed hosting platforms and there have been IA changes since.